### PR TITLE
Add release workflow

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -4,3 +4,8 @@ repository:
   description: A kubectl plugin to execute hooks exposed by a Kubernetes resource around a port-forward action.
   topics: kubernetes, kubectl
   allow_auto_merge: true
+branches:
+  - name: master
+    protection:
+      required_pull_request_reviews: null
+      required_status_checks: null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    tags:
+      - 'v*'
+name: Release
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,10 @@
+
+builds:
+  - binary: kubectl-port_forward_hooks
+brews:
+  - tap:
+      owner: takescoop
+      name: kubectl-port-forward-hooks
+    folder: HomebrewFormula
+    homepage: https://github.com/takescoop/kubectl-port-forward-hooks
+    description: A kubectl plugin to execute hooks exposed by a Kubernetes resource around a port-forward action.


### PR DESCRIPTION
Adds a release workflow on triggered on git tag. The binary builds with the name `kubectl-port_forward_hooks` so I'm hoping that's enough be able to be able to run brew install kubectl-port-forward-hooks after tapping and have it installed with the binary name.