### PR TITLE
Log errors

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -97,7 +97,7 @@ func (c Command) execute(ctx context.Context, config *Config, args *Args, previo
 
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(streams.ErrOut, "Error running command: %s\n", c)
-		fmt.Fprintf(streams.ErrOut, "%s\n", berr.String())
+		fmt.Fprintf(streams.ErrOut, "%s\n", berr)
 
 		return nil, err
 	}


### PR DESCRIPTION
When a command errors, sometimes the error returned by the command isn't very useful

```sh
# mysterious command surfaced from some command ran by the plugin
$ go run . -n release service/<svc>
Error: exit status 254

# command and error out are surfaced
$ go run . -n release service/<svc>
Error running command: aws rds describe-db-instances --db-instance-identifier <instance> --query DBInstances[0].DBInstanceIdentifier

An error occurred (InvalidClientTokenId) when calling the DescribeDBInstances operation: The security token included in the request is invalid.

Error: exit status 254
```