### PR TITLE
Installation instructions and make repo public

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -4,6 +4,7 @@ repository:
   description: A kubectl plugin to run exec hooks exposed by a Kubernetes pod around a port-forward action.
   topics: kubernetes, kubectl
   allow_auto_merge: true
+  private: false
 branches:
   - name: master
     protection:

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ A kubectl plugin to run exec hooks exposed by a Kubernetes pod around a port-for
 
 ```sh
 brew tap takescoop/kubectl-exec-forward https://github.com/takescoop/kubectl-exec-forward.git
-brew kubectl-exec-forward
+brew install kubectl-exec-forward
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ A kubectl plugin to run exec hooks exposed by a Kubernetes pod around a port-for
 ## Install
 
 ```sh
-brew tap takescoop/kubectl-exec-forward https://github.com/TakeScoop/kubectl-exec-forward.git
+brew tap takescoop/kubectl-exec-forward https://github.com/takescoop/kubectl-exec-forward.git
 brew kubectl-exec-forward
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # kubectl-exec-forward
 
 A kubectl plugin to run exec hooks exposed by a Kubernetes pod around a port-forward action.
+
+## Install
+
+```sh
+brew tap takescoop/kubectl-exec-forward https://github.com/TakeScoop/kubectl-exec-forward.git
+brew kubectl-exec-forward
+```


### PR DESCRIPTION
Testing out brew install, I ran into a couple things which are addressed here

1) 404 when requesting the release artifact. While this can likely be achieved by passing some credentials to brew, we were planning on making this repo public anyway so I figured no better time than the present
2) [brew tap \<user\>/\<repo\>](https://docs.brew.sh/Taps) expects the repo name to be prefixed with `homebrew-`. This goes hand in hand putting the homebrew formula in a separate repo, which we chose not to do. You can however pass a URL to `brew tap` in which case brew handles the URL just fine. 