### PR TITLE
Ensure main command always streams to console

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -91,9 +91,12 @@ func (c Command) execute(ctx context.Context, config *Config, args *Args, previo
 		ews = append(ews, streams.ErrOut)
 	}
 
+	if c.Interactive {
+		cmd.Stdin = streams.In
+	}
+
 	cmd.Stdout = io.MultiWriter(ows...)
 	cmd.Stderr = io.MultiWriter(ews...)
-	cmd.Stdin = streams.In
 
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(streams.ErrOut, "Error running command: %s\n", c)

--- a/internal/command/hooks.go
+++ b/internal/command/hooks.go
@@ -29,6 +29,8 @@ func newHooks(annotations map[string]string, config *Config) (*Hooks, error) {
 		return nil, err
 	}
 
+	c.Interactive = true
+
 	if config != nil {
 		if len(config.Command) > 0 {
 			c.Command = append(config.Command, c.Command[1:]...)

--- a/internal/command/hooks_test.go
+++ b/internal/command/hooks_test.go
@@ -11,7 +11,7 @@ func TestNewHooks(t *testing.T) {
 		actual, err := newHooks(map[string]string{}, nil)
 		assert.NoError(t, err)
 
-		assert.Equal(t, &Hooks{}, actual)
+		assert.Equal(t, &Hooks{Command: Command{Interactive: true}}, actual)
 	})
 
 	t.Run("return hooks with pre-connect commands", func(t *testing.T) {
@@ -20,9 +20,7 @@ func TestNewHooks(t *testing.T) {
 		}, nil)
 		assert.NoError(t, err)
 
-		assert.Equal(t, &Hooks{
-			Pre: Commands{{Command: []string{"echo", "hello"}}},
-		}, actual)
+		assert.Equal(t, Commands{{Command: []string{"echo", "hello"}}}, actual.Pre)
 	})
 
 	t.Run("return hooks with post-connect commands", func(t *testing.T) {
@@ -31,9 +29,7 @@ func TestNewHooks(t *testing.T) {
 		}, nil)
 		assert.NoError(t, err)
 
-		assert.Equal(t, &Hooks{
-			Post: Commands{{Command: []string{"echo", "hello"}}},
-		}, actual)
+		assert.Equal(t, Commands{{Command: []string{"echo", "hello"}}}, actual.Post)
 	})
 
 	t.Run("return hooks with a main command", func(t *testing.T) {
@@ -42,9 +38,7 @@ func TestNewHooks(t *testing.T) {
 		}, nil)
 		assert.NoError(t, err)
 
-		assert.Equal(t, &Hooks{
-			Command: Command{Command: []string{"echo", "hello"}},
-		}, actual)
+		assert.Equal(t, Command{Command: []string{"echo", "hello"}, Interactive: true}, actual.Command)
 	})
 
 	t.Run("replace the command portion of the main command if command-override is supplied", func(t *testing.T) {
@@ -54,7 +48,7 @@ func TestNewHooks(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, &Hooks{
-			Command: Command{Command: []string{"touch", "foo", "hello"}},
+			Command: Command{Command: []string{"touch", "foo", "hello"}, Interactive: true},
 		}, actual)
 	})
 
@@ -65,7 +59,7 @@ func TestNewHooks(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, &Hooks{
-			Command: Command{Command: []string{"echo", "hello"}},
+			Command: Command{Command: []string{"echo", "hello"}, Interactive: true},
 		}, actual)
 	})
 }


### PR DESCRIPTION
Ensures that the console IO is added to the main command by always setting the main command to interactive mode.

This change gives a more intuitive experience for commands, especially override commands where you would expect to see your command output (`psql -c 'select * from foo;'`) without adding any additional flags regarding output.