### PR TITLE
Add json getter as template helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/gjson v1.12.1
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
 	k8s.io/cli-runtime v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -540,6 +540,12 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tidwall/gjson v1.12.1 h1:ikuZsLdhr8Ws0IdROXUS1Gi4v9Z4pGqpX/CvJkxvfpo=
+github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -40,8 +40,8 @@ func (c Command) toCmd(ctx context.Context, config *Config, cmdArgs *Args, outpu
 
 	for i, a := range rawArgs {
 		tpl, err := template.New(c.ID).Option("missingkey=error").Funcs(template.FuncMap{
-			"trim":    strings.TrimSpace,
-			"jsonGet": gjson.Get,
+			"trim": strings.TrimSpace,
+			"json": gjson.Get,
 		}).Parse(a)
 		if err != nil {
 			return nil, err

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/tidwall/gjson"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -39,7 +40,8 @@ func (c Command) toCmd(ctx context.Context, config *Config, cmdArgs *Args, outpu
 
 	for i, a := range rawArgs {
 		tpl, err := template.New(c.ID).Option("missingkey=error").Funcs(template.FuncMap{
-			"trim": strings.TrimSpace,
+			"trim":    strings.TrimSpace,
+			"jsonGet": gjson.Get,
 		}).Parse(a)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Adds a template helper to parse JSON outputs. While a command could probably call out to something like jq to help, it would be nice to have the ability to parse JSON output baked in to the templating so we can do something like this:

```
Command: ["echo", "{\"user\": \"foo\"}"], ID: "credentials"
Command: ["echo", "{{ json .Outputs.credentials.Stdout \"user\" }}"]
```

[tidwall/gsjson](https://github.com/tidwall/gjson) is the library used