### PR TITLE
Close forwarding tunnel when command is finished

### DIFF
--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -58,6 +58,13 @@ func newForwardCommand(streams *genericclioptions.IOStreams, version string) *co
 
 			config.Verbose = v
 
+			p, err := flags.GetBool("persist")
+			if err != nil {
+				return err
+			}
+
+			config.Persist = p
+
 			cancelCtx, cancel := context.WithCancel(ctx)
 
 			go func() {
@@ -73,6 +80,7 @@ func newForwardCommand(streams *genericclioptions.IOStreams, version string) *co
 	cmd.Flags().StringArray("arg", []string{}, "key=value arguments to be passed to commands")
 	cmd.Flags().Bool("verbose", false, "Whether to write command outputs to console")
 	cmd.Flags().Duration("pod-timeout", 500, "Time to wait for an attachable pod to become available")
+	cmd.Flags().Bool("persist", false, "Whether to persist the connection after the main command has executed")
 
 	clientcmd.BindOverrideFlags(&overrides, cmd.PersistentFlags(), clientcmd.RecommendedConfigOverrideFlags(""))
 

--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -80,7 +80,7 @@ func newForwardCommand(streams *genericclioptions.IOStreams, version string) *co
 	cmd.Flags().StringArray("arg", []string{}, "key=value arguments to be passed to commands")
 	cmd.Flags().Bool("verbose", false, "Whether to write command outputs to console")
 	cmd.Flags().Duration("pod-timeout", 500, "Time to wait for an attachable pod to become available")
-	cmd.Flags().Bool("persist", false, "Whether to persist the connection after the main command has executed")
+	cmd.Flags().Bool("persist", false, "Whether to persist the connection after the main command has finished")
 
 	clientcmd.BindOverrideFlags(&overrides, cmd.PersistentFlags(), clientcmd.RecommendedConfigOverrideFlags(""))
 

--- a/cmd/forward_test.go
+++ b/cmd/forward_test.go
@@ -105,6 +105,7 @@ func TestRunForwardCommand(t *testing.T) {
 		"--namespace",
 		pod.Namespace,
 		"--verbose",
+		"--persist",
 		fmt.Sprintf("pod/%s", pod.Name),
 		fmt.Sprintf("%d:%d", localPort, pod.Spec.Containers[0].Ports[0].ContainerPort),
 	})

--- a/internal/command/config.go
+++ b/internal/command/config.go
@@ -5,4 +5,5 @@ type Config struct {
 	LocalPort int
 	Verbose   bool
 	Command   []string
+	Persist   bool
 }


### PR DESCRIPTION
Closes the port-forwarding connection when the command is finished unless the `--persist` flag is passed. This actually works a bit nicer than I had anticipated because blocking commands (`psql` w/ no `-c` flag) will block until they are finished and once finished, send a done msg. So now something like using `\q` will close the `psql` session and the forwarding tunnel together.

fixes #40 