### PR TITLE
Send command IO directly to passed streams

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -14,11 +14,20 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-// Command represents a runnable command.
-type Command struct {
+type commandInput struct {
 	ID          string   `json:"id"`
 	Command     []string `json:"command"`
 	Interactive bool     `json:"interactive"`
+	Description string   `json:"description"`
+}
+
+// Command represents a runnable command.
+type Command struct {
+	ID          string
+	Command     []string
+	Interactive bool
+	Description string
+	hookType    string
 }
 
 type templateInputs struct {
@@ -80,6 +89,12 @@ func (c Command) execute(ctx context.Context, config *Config, args *Args, previo
 	bout := new(bytes.Buffer)
 	berr := new(bytes.Buffer)
 
+	// Send main command IO directly to passed streams to avoid missed prompts on interactive commands
+	// if c.hookType == commandHookType {
+	// 	cmd.Stdout = streams.Out
+	// 	cmd.Stderr = streams.ErrOut
+	// 	cmd.Stdin = streams.In
+	// } else {
 	ows := []io.Writer{bout}
 	ews := []io.Writer{berr}
 
@@ -94,6 +109,7 @@ func (c Command) execute(ctx context.Context, config *Config, args *Args, previo
 
 	cmd.Stdout = io.MultiWriter(ows...)
 	cmd.Stderr = io.MultiWriter(ews...)
+	// }
 
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(streams.ErrOut, "Error running command: %v\n", cmd.Args)
@@ -102,7 +118,7 @@ func (c Command) execute(ctx context.Context, config *Config, args *Args, previo
 		return nil, err
 	}
 
-	if c.ID != "" {
+	if c.ID != "" && c.hookType != commandHookType {
 		outputs[c.ID] = Output{
 			Stdout: bout.String(),
 			Stderr: berr.String(),
@@ -119,9 +135,34 @@ func parseComand(annotations map[string]string, key string) (command Command, er
 		return command, nil
 	}
 
-	if err := json.Unmarshal([]byte(v), &command); err != nil {
+	var ci commandInput
+
+	if err := json.Unmarshal([]byte(v), &ci); err != nil {
 		return command, err
 	}
 
-	return command, nil
+	return ci.toCommand(getHookTypeFromAnnotationKey(key)), nil
+}
+
+func (ci commandInput) toCommand(hookType string) Command {
+	return Command{
+		ID:          ci.ID,
+		Command:     ci.Command,
+		Interactive: ci.Interactive,
+		hookType:    hookType,
+	}
+}
+
+// Returns the hook type based on the passed annotation key.
+func getHookTypeFromAnnotationKey(key string) string {
+	switch key {
+	case PreAnnotation:
+		return preConnectHookType
+	case PostAnnotation:
+		return postConnectHookType
+	case CommandAnnotation:
+		return commandHookType
+	default:
+		return ""
+	}
 }

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -10,6 +10,8 @@ import (
 // Commands stores a slice of commands and provides some helper execution methods.
 type Commands []*Command
 
+type commandInputs []*commandInput
+
 // execute runs each command in the calling slice sequentially using the passed config and the outputs accumulated to that point.
 func (c Commands) execute(ctx context.Context, config *Config, args *Args, previousOutputs map[string]Output, streams *genericclioptions.IOStreams) (outputs map[string]Output, err error) {
 	outputs = map[string]Output{}
@@ -34,8 +36,15 @@ func parseCommands(annotations map[string]string, key string) (commands Commands
 		return commands, nil
 	}
 
-	if err := json.Unmarshal([]byte(v), &commands); err != nil {
+	var inputs commandInputs
+
+	if err := json.Unmarshal([]byte(v), &inputs); err != nil {
 		return nil, err
+	}
+
+	for _, c := range inputs {
+		cmd := c.toCommand(getHookTypeFromAnnotationKey(key))
+		commands = append(commands, &cmd)
 	}
 
 	return commands, err

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -15,7 +15,7 @@ func TestParseCommands(t *testing.T) {
 		assert.NoError(t, err)
 
 		expected := Commands{
-			{ID: "", Command: []string{"echo", "pre"}},
+			{ID: "", Command: []string{"echo", "pre"}, hookType: preConnectHookType},
 		}
 		assert.Equal(t, expected, commands)
 	})
@@ -28,8 +28,8 @@ func TestParseCommands(t *testing.T) {
 		assert.NoError(t, err)
 
 		expected := Commands{
-			{ID: "", Command: []string{"echo", "post1"}},
-			{ID: "foo", Command: []string{"echo", "post2"}},
+			{ID: "", Command: []string{"echo", "post1"}, hookType: postConnectHookType},
+			{ID: "foo", Command: []string{"echo", "post2"}, hookType: postConnectHookType},
 		}
 		assert.Equal(t, expected, commands)
 	})

--- a/internal/command/hooks.go
+++ b/internal/command/hooks.go
@@ -7,6 +7,12 @@ type Hooks struct {
 	Command Command
 }
 
+const (
+	preConnectHookType  string = "pre-connect"
+	postConnectHookType string = "post-connect"
+	commandHookType     string = "command"
+)
+
 // newHooks returns a new Hooks struct assembled from the passed annotations.
 func newHooks(annotations map[string]string, config *Config) (*Hooks, error) {
 	pre, err := parseCommands(annotations, PreAnnotation)
@@ -28,8 +34,6 @@ func newHooks(annotations map[string]string, config *Config) (*Hooks, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	c.Interactive = true
 
 	if config != nil {
 		if len(config.Command) > 0 {

--- a/internal/command/hooks_test.go
+++ b/internal/command/hooks_test.go
@@ -11,7 +11,7 @@ func TestNewHooks(t *testing.T) {
 		actual, err := newHooks(map[string]string{}, nil)
 		assert.NoError(t, err)
 
-		assert.Equal(t, &Hooks{Command: Command{Interactive: true}}, actual)
+		assert.Equal(t, &Hooks{Command: Command{}}, actual)
 	})
 
 	t.Run("return hooks with pre-connect commands", func(t *testing.T) {
@@ -20,7 +20,7 @@ func TestNewHooks(t *testing.T) {
 		}, nil)
 		assert.NoError(t, err)
 
-		assert.Equal(t, Commands{{Command: []string{"echo", "hello"}}}, actual.Pre)
+		assert.Equal(t, Commands{{Command: []string{"echo", "hello"}, hookType: preConnectHookType}}, actual.Pre)
 	})
 
 	t.Run("return hooks with post-connect commands", func(t *testing.T) {
@@ -29,7 +29,7 @@ func TestNewHooks(t *testing.T) {
 		}, nil)
 		assert.NoError(t, err)
 
-		assert.Equal(t, Commands{{Command: []string{"echo", "hello"}}}, actual.Post)
+		assert.Equal(t, Commands{{Command: []string{"echo", "hello"}, hookType: postConnectHookType}}, actual.Post)
 	})
 
 	t.Run("return hooks with a main command", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestNewHooks(t *testing.T) {
 		}, nil)
 		assert.NoError(t, err)
 
-		assert.Equal(t, Command{Command: []string{"echo", "hello"}, Interactive: true}, actual.Command)
+		assert.Equal(t, Command{Command: []string{"echo", "hello"}, hookType: commandHookType}, actual.Command)
 	})
 
 	t.Run("replace the command portion of the main command if command-override is supplied", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestNewHooks(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, &Hooks{
-			Command: Command{Command: []string{"touch", "foo", "hello"}, Interactive: true},
+			Command: Command{Command: []string{"touch", "foo", "hello"}, hookType: commandHookType},
 		}, actual)
 	})
 
@@ -59,7 +59,7 @@ func TestNewHooks(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, &Hooks{
-			Command: Command{Command: []string{"echo", "hello"}, Interactive: true},
+			Command: Command{Command: []string{"echo", "hello"}, hookType: commandHookType},
 		}, actual)
 	})
 }


### PR DESCRIPTION
Since we are doubling down on `psql`, I think it's important to make that experience as dope as possible. For some reason I can't figure out, when using a Mutliwriter (even if stdout/stderr are added), the `psql` prompts do not show. With the addition of `hookType` on the Command struct (overlap from https://github.com/TakeScoop/kubectl-exec-forward/pull/43), we can single out the main command from within the execute function and attach its execution directly to the passed streams. 

```sh
# before
$ go run . svc/<svc> <port> -- psql
Forwarding from 127.0.0.1:5432 -> 5432
Forwarding from [::1]:5432 -> 5432
Handling connection for 5432
select * from foo;
ERROR:  relation "foo" does not exist
LINE 1: select * from foo;

# after
$ go run . svc/<svc> <port> -- psql
Forwarding from 127.0.0.1:5432 -> 5432
Forwarding from [::1]:5432 -> 5432
Handling connection for 5432
psql (14.0, server 11.12)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.

database=> select * from foo;
ERROR:  relation "foo" does not exist
LINE 1: select * from foo;
                      ^
database=> 
```