### PR TITLE
Add `sensitive` templating function that prevents printing of sensitive info

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -106,7 +106,10 @@ func (c Command) execute(ctx context.Context, config *Config, args *Args, previo
 	cmd.Stderr = io.MultiWriter(ews...)
 
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(streams.ErrOut, "Error running command: %v\n", cmd.Args)
+		name, args, _ := c.render(config, args, outputs, false)
+		args = append([]string{name}, args...)
+
+		fmt.Fprintf(streams.ErrOut, "Error running command: %v\n", args)
 		fmt.Fprintf(streams.ErrOut, "%s\n", berr)
 
 		return nil, err

--- a/internal/command/sensitive.go
+++ b/internal/command/sensitive.go
@@ -1,0 +1,1 @@
+package command

--- a/internal/command/sensitive.go
+++ b/internal/command/sensitive.go
@@ -1,1 +1,13 @@
 package command
+
+const sensitiveAsterisks = "********"
+
+func sensitiveFunc(showSensitive bool) func(string) string {
+	return func(s string) string {
+		if showSensitive {
+			return s
+		}
+
+		return sensitiveAsterisks
+	}
+}


### PR DESCRIPTION
Adds a new `sensitive` template function. When converting to an `*exec.Command`, the function is a noop. When the internal `render()` method is called with `showSensitive = false`, anything piped to `sensitive` is redacted. 

The package is a bit short of tests and definitely needs coverage for templating, this included.