### PR TITLE
Stream command to passed IO skipping multiwriter

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -75,7 +75,7 @@ func (c Command) render(config *Config, cmdArgs *Args, outputs map[string]Output
 }
 
 // execute runs the command with the given config and outputs.
-func (c Command) execute(ctx context.Context, config *Config, args *Args, previousOutputs map[string]Output, streams *genericclioptions.IOStreams) (map[string]Output, error) {
+func (c Command) execute(ctx context.Context, config *Config, args *Args, previousOutputs map[string]Output, streams *genericclioptions.IOStreams, storeOutput bool) (map[string]Output, error) {
 	outputs := map[string]Output{}
 
 	for k, v := range previousOutputs {
@@ -102,8 +102,13 @@ func (c Command) execute(ctx context.Context, config *Config, args *Args, previo
 		cmd.Stdin = streams.In
 	}
 
-	cmd.Stdout = io.MultiWriter(ows...)
-	cmd.Stderr = io.MultiWriter(ews...)
+	if storeOutput {
+		cmd.Stdout = io.MultiWriter(ows...)
+		cmd.Stderr = io.MultiWriter(ews...)
+	} else {
+		cmd.Stdout = streams.Out
+		cmd.Stderr = streams.ErrOut
+	}
 
 	if err := cmd.Run(); err != nil {
 		name, args, _ := c.render(config, args, outputs, false)

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -11,14 +11,14 @@ import (
 type Commands []*Command
 
 // execute runs each command in the calling slice sequentially using the passed config and the outputs accumulated to that point.
-func (c Commands) execute(ctx context.Context, config *Config, args *Args, previousOutputs map[string]Output, streams *genericclioptions.IOStreams) (outputs map[string]Output, err error) {
+func (c Commands) execute(ctx context.Context, config *Config, args *Args, previousOutputs map[string]Output, streams *genericclioptions.IOStreams, storeOutput bool) (outputs map[string]Output, err error) {
 	outputs = map[string]Output{}
 	for k, v := range previousOutputs {
 		outputs[k] = v
 	}
 
 	for _, command := range c {
-		outputs, err = command.execute(ctx, config, args, outputs, streams)
+		outputs, err = command.execute(ctx, config, args, outputs, streams, storeOutput)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cli
 
 	outputs := map[string]Output{}
 
-	if outputs, err = hooks.Pre.execute(ctx, hooksConfig, args, outputs, streams); err != nil {
+	if outputs, err = hooks.Pre.execute(ctx, hooksConfig, args, outputs, streams, true); err != nil {
 		return err
 	}
 
@@ -59,11 +59,11 @@ func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cli
 	go func() {
 		<-readyChan
 
-		if outputs, err = hooks.Post.execute(cancelCtx, hooksConfig, args, outputs, streams); err != nil {
+		if outputs, err = hooks.Post.execute(cancelCtx, hooksConfig, args, outputs, streams, true); err != nil {
 			hookErrChan <- err
 		}
 
-		if _, err = hooks.Command.execute(cancelCtx, hooksConfig, args, outputs, streams); err != nil {
+		if _, err = hooks.Command.execute(cancelCtx, hooksConfig, args, outputs, streams, false); err != nil {
 			hookErrChan <- err
 		}
 


### PR DESCRIPTION
Per the [recommendation](https://github.com/TakeScoop/kubectl-exec-forward/pull/43#pullrequestreview-839536784) to skip storing hook types on commands, execute takes an additional bool `storeOutputs` which denotes whether to skip using a multiwriter for the main command output or whether to write directly to the passed io streams. This change resolves an issue with psql IO where when using a multiwriter the psql prompts are not streamed to the console. This change is not ideal, but I would rather launch with prompts and fix it internally than launch with missing prompts, especially because psql is the default command.