### PR TITLE
Add version field

### DIFF
--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -22,9 +22,10 @@ func newForwardCommand(streams *genericclioptions.IOStreams, version string) *co
 	kubeConfigFlags := genericclioptions.NewConfigFlags(false)
 
 	cmd := &cobra.Command{
-		Use:   "kubectl exec-forward TYPE/NAME PORT [options] -- [command...]",
-		Short: "Port forward to Kubernetes resources and execute commands found in annotations",
-		Args:  cobra.MinimumNArgs(2),
+		Use:     "kubectl exec-forward TYPE/NAME PORT [options] -- [command...]",
+		Short:   "Port forward to Kubernetes resources and execute commands found in annotations",
+		Args:    cobra.MinimumNArgs(2),
+		Version: version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			flags := cmd.Flags()


### PR DESCRIPTION
Adds the [Version](https://github.com/spf13/cobra/blob/master/user_guide.md#version-flag) field to the Cobra command, which allows users to bypass the minimum args requirement and print the version using `kubectl exec-forward version`