### PR TITLE
Stream interactive commands to console (skip buffer capture)

### DIFF
--- a/cmd/forward_test.go
+++ b/cmd/forward_test.go
@@ -55,12 +55,14 @@ type SafeBuffer struct {
 func (b *SafeBuffer) Write(bs []byte) (int, error) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
+
 	return b.buf.Write(bs)
 }
 
 func (b *SafeBuffer) String() string {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
+
 	return b.buf.String()
 }
 

--- a/cmd/forward_test.go
+++ b/cmd/forward_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -48,7 +49,7 @@ func TestParseArgs(t *testing.T) {
 
 type SafeBuffer struct {
 	mutex sync.RWMutex
-	buf   []byte
+	buf   bytes.Buffer
 }
 
 func (b *SafeBuffer) Write(bs []byte) (int, error) {
@@ -57,7 +58,7 @@ func (b *SafeBuffer) Write(bs []byte) (int, error) {
 	}
 
 	b.mutex.Lock()
-	b.buf = append(b.buf, bs...)
+	b.buf.Write(bs)
 	b.mutex.Unlock()
 
 	return len(bs), nil
@@ -65,7 +66,7 @@ func (b *SafeBuffer) Write(bs []byte) (int, error) {
 
 func (b *SafeBuffer) String() string {
 	b.mutex.Lock()
-	s := string(b.buf)
+	s := b.buf.String()
 	b.mutex.Unlock()
 
 	return s

--- a/cmd/forward_test.go
+++ b/cmd/forward_test.go
@@ -53,23 +53,15 @@ type SafeBuffer struct {
 }
 
 func (b *SafeBuffer) Write(bs []byte) (int, error) {
-	if len(bs) == 0 {
-		return 0, nil
-	}
-
 	b.mutex.Lock()
-	b.buf.Write(bs)
-	b.mutex.Unlock()
-
-	return len(bs), nil
+	defer b.mutex.Unlock()
+	return b.buf.Write(bs)
 }
 
 func (b *SafeBuffer) String() string {
 	b.mutex.Lock()
-	s := b.buf.String()
-	b.mutex.Unlock()
-
-	return s
+	defer b.mutex.Unlock()
+	return b.buf.String()
 }
 
 func TestRunForwardCommand(t *testing.T) {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -147,7 +147,7 @@ func (c Command) execute(ctx context.Context, config *Config, args *Args, previo
 		return nil, err
 	}
 
-	if c.ID != "" {
+	if c.ID != "" || !c.Interactive {
 		outputs[c.ID] = Output{
 			Stdout: outBuff.String(),
 			Stderr: errBuff.String(),


### PR DESCRIPTION
Send interactive commands directly to the passed IO streams, rather than writing to both buffers and IO streams. This removes the option to read command output from other commands if the initial command is interactive. Interactive commands produce unstructured output and should not be relied upon to render subsequent commands. 