### PR TITLE
specify tap repo in `brew install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,5 @@ A kubectl plugin to run exec hooks exposed by a Kubernetes pod around a port-for
 ## Install
 
 ```sh
-brew tap takescoop/formulas
-brew install kubectl-exec-forward
+brew install takescoop/formulas/kubectl-exec-forward
 ```


### PR DESCRIPTION
Specifies the fully qualified formula in `install` rather than separately tapping

https://docs.brew.sh/Manpage#specifying-formulae