### PR TITLE
Template portions of Config instead of the whole struct

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -24,9 +24,9 @@ type Command struct {
 }
 
 type templateInputs struct {
-	Config  *Config
-	Args    *Args
-	Outputs map[string]Output
+	LocalPort int
+	Args      *Args
+	Outputs   map[string]Output
 }
 
 // toCmd returns a golang cmd object from the calling command.
@@ -63,9 +63,9 @@ func (c Command) render(config *Config, cmdArgs *Args, outputs map[string]Output
 		o := new(bytes.Buffer)
 
 		if err := tpl.Execute(o, &templateInputs{
-			Config:  config,
-			Args:    cmdArgs,
-			Outputs: outputs,
+			LocalPort: config.LocalPort,
+			Args:      cmdArgs,
+			Outputs:   outputs,
 		}); err != nil {
 			return "", nil, err
 		}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -35,7 +35,7 @@ func TestToCmd(t *testing.T) {
 	t.Run("templates config inputs into the command", func(t *testing.T) {
 		c := &Command{
 			ID:      "foo",
-			Command: []string{"echo", "{{.Config.LocalPort}}", "{{.Config.Verbose}}"},
+			Command: []string{"echo", "{{.LocalPort}}"},
 		}
 
 		cmd, err := c.toCmd(context.Background(), &Config{
@@ -44,7 +44,7 @@ func TestToCmd(t *testing.T) {
 		}, &Args{}, map[string]Output{})
 		assert.NoError(t, err)
 
-		assert.Equal(t, []string{"echo", "5678", "true"}, cmd.Args)
+		assert.Equal(t, []string{"echo", "5678"}, cmd.Args)
 	})
 
 	t.Run("templates argument inputs into the command", func(t *testing.T) {


### PR DESCRIPTION
The idea here is to `.Config` from templating in favor of the interesting portions of the config at the top level namespace (`.Config.LocalPort -> .LocalPort`)