### PR TITLE
Remove stdout/stderr from templating

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -60,13 +60,13 @@ func (c Command) render(config *Config, cmdArgs *Args, outputs map[string]Output
 			return "", nil, err
 		}
 
-		o := new(bytes.Buffer)
-
 		outMap := map[string]string{}
 
 		for id, output := range outputs {
 			outMap[id] = output.Stdout
 		}
+
+		o := new(bytes.Buffer)
 
 		if err := tpl.Execute(o, &templateInputs{
 			LocalPort: config.LocalPort,

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -26,7 +26,7 @@ type Command struct {
 type templateInputs struct {
 	Config  *Config
 	Args    *Args
-	Outputs map[string]Output
+	Outputs map[string]string
 }
 
 // toCmd returns a golang cmd object from the calling command.
@@ -62,10 +62,16 @@ func (c Command) render(config *Config, cmdArgs *Args, outputs map[string]Output
 
 		o := new(bytes.Buffer)
 
+		outMap := map[string]string{}
+
+		for id, output := range outputs {
+			outMap[id] = output.Stdout
+		}
+
 		if err := tpl.Execute(o, &templateInputs{
 			Config:  config,
 			Args:    cmdArgs,
-			Outputs: outputs,
+			Outputs: outMap,
 		}); err != nil {
 			return "", nil, err
 		}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -62,7 +62,7 @@ func TestToCmd(t *testing.T) {
 	t.Run("templates outputs inputs into the command", func(t *testing.T) {
 		c := &Command{
 			ID:      "foo",
-			Command: []string{"echo", "{{.Outputs.foo.Stdout}}"},
+			Command: []string{"echo", "{{.Outputs.foo}}"},
 		}
 
 		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, map[string]Output{

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -14,7 +14,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, map[string]Output{})
+		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo"}, cmd.Args)
@@ -26,7 +26,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "hello", "world"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, map[string]Output{})
+		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "hello", "world"}, cmd.Args)
@@ -41,7 +41,7 @@ func TestToCmd(t *testing.T) {
 		cmd, err := c.toCmd(context.Background(), &Config{
 			LocalPort: 5678,
 			Verbose:   true,
-		}, &Args{}, map[string]Output{})
+		}, &Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "5678"}, cmd.Args)
@@ -53,7 +53,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.Args.foo}}"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{"foo": "bar"}, map[string]Output{})
+		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{"foo": "bar"}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "bar"}, cmd.Args)
@@ -65,7 +65,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.Outputs.foo}}"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, map[string]Output{
+		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{
 			"foo": {
 				Stdout: "hello world",
 				Stderr: "",
@@ -82,7 +82,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.DoesNotExist}}"},
 		}
 
-		_, err := c.toCmd(context.Background(), &Config{}, &Args{}, map[string]Output{})
+		_, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{})
 		assert.Error(t, err)
 	})
 
@@ -91,7 +91,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "foo"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, map[string]Output{})
+		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "foo"}, cmd.Args)

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -11,8 +11,8 @@ import (
 type Commands []*Command
 
 // execute runs each command in the calling slice sequentially using the passed config and the outputs accumulated to that point.
-func (c Commands) execute(ctx context.Context, config *Config, args *Args, previousOutputs map[string]Output, streams *genericclioptions.IOStreams) (outputs map[string]Output, err error) {
-	outputs = map[string]Output{}
+func (c Commands) execute(ctx context.Context, config *Config, args *Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (outputs Outputs, err error) {
+	outputs = Outputs{}
 	for k, v := range previousOutputs {
 		outputs[k] = v
 	}

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -1,0 +1,7 @@
+package command
+
+// Output stores command output.
+type Output struct {
+	Stdout string
+	Stderr string
+}

--- a/internal/command/outputs.go
+++ b/internal/command/outputs.go
@@ -1,7 +1,15 @@
 package command
 
-// Output stores command output.
-type Output struct {
-	Stdout string
-	Stderr string
+// Outputs is a collection of Output structs.
+type Outputs map[string]Output
+
+// Stdout returns the output Stdout by the Output ID.
+func (o Outputs) Stdout() map[string]string {
+	out := map[string]string{}
+
+	for id, output := range o {
+		out[id] = output.Stdout
+	}
+
+	return out
 }

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -42,7 +42,7 @@ func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cli
 		return err
 	}
 
-	outputs := map[string]Output{}
+	outputs := Outputs{}
 
 	if outputs, err = hooks.Pre.execute(ctx, hooksConfig, args, outputs, streams); err != nil {
 		return err


### PR DESCRIPTION
Removes the .Stdout/.Stderr path from the .Outputs templating path. There shouldn't be a need to us stderr in a subsequent command. As a result of the change, commands can use the command ID directly instead of `.Outputs.<id>.Stdout`

