### PR TITLE
Rename lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: Lint
 
 on:
   push:


### PR DESCRIPTION
The workflow name for linting has been bothering me, the name of the workflow should be what it does not the tool it uses. 