### PR TITLE
Refactor `Args` type

### DIFF
--- a/internal/command/args.go
+++ b/internal/command/args.go
@@ -8,7 +8,7 @@ import (
 type Args map[string]string
 
 // ParseArgsFromAnnotations parses key value pairs from the passed annotations map, adds any overrides passed and returns a new args map.
-func ParseArgsFromAnnotations(annotations map[string]string, overrides map[string]string) (*Args, error) {
+func ParseArgsFromAnnotations(annotations map[string]string, overrides map[string]string) (Args, error) {
 	args := Args{}
 
 	v, ok := annotations[ArgsAnnotation]
@@ -22,5 +22,5 @@ func ParseArgsFromAnnotations(annotations map[string]string, overrides map[strin
 		args[k] = v
 	}
 
-	return &args, nil
+	return args, nil
 }

--- a/internal/command/args.go
+++ b/internal/command/args.go
@@ -7,8 +7,8 @@ import (
 // Args store command specific arguments to be passed to the hook commands.
 type Args map[string]string
 
-// parseArgs parses key value pairs from the passed annotations map, adds any overrides passed and returns a new args map.
-func parseArgs(annotations map[string]string, overrides map[string]string) (*Args, error) {
+// ParseArgsFromAnnotations parses key value pairs from the passed annotations map, adds any overrides passed and returns a new args map.
+func ParseArgsFromAnnotations(annotations map[string]string, overrides map[string]string) (*Args, error) {
 	args := Args{}
 
 	v, ok := annotations[ArgsAnnotation]

--- a/internal/command/args.go
+++ b/internal/command/args.go
@@ -8,7 +8,7 @@ import (
 type Args map[string]string
 
 // ParseArgsFromAnnotations parses key value pairs from the passed annotations map, adds any overrides passed and returns a new args map.
-func ParseArgsFromAnnotations(annotations map[string]string, overrides map[string]string) (Args, error) {
+func ParseArgsFromAnnotations(annotations map[string]string) (Args, error) {
 	args := Args{}
 
 	v, ok := annotations[ArgsAnnotation]
@@ -18,9 +18,12 @@ func ParseArgsFromAnnotations(annotations map[string]string, overrides map[strin
 		}
 	}
 
-	for k, v := range overrides {
-		args[k] = v
-	}
-
 	return args, nil
+}
+
+// Merge merges the provided overrides into the existing args, mutating the existing args.
+func (a Args) Merge(overrides map[string]string) {
+	for k, v := range overrides {
+		a[k] = v
+	}
 }

--- a/internal/command/args_test.go
+++ b/internal/command/args_test.go
@@ -15,6 +15,7 @@ func TestParseArgsFromAnnotations(t *testing.T) {
 		annotations map[string]string
 		overrides   map[string]string
 		expected    Args
+		error       string
 	}{
 		{
 			name:        "basic",
@@ -42,6 +43,13 @@ func TestParseArgsFromAnnotations(t *testing.T) {
 			expected:  Args{"username": "bar"},
 		},
 		{
+			name: "invalid json",
+			annotations: map[string]string{
+				ArgsAnnotation: "",
+			},
+			error: "unexpected end of JSON input",
+		},
+		{
 			name:     "no annotation",
 			expected: Args{},
 		},
@@ -54,8 +62,13 @@ func TestParseArgsFromAnnotations(t *testing.T) {
 			t.Parallel()
 
 			actual, err := ParseArgsFromAnnotations(tc.annotations, tc.overrides)
-			require.NoError(t, err)
 
+			if tc.error != "" {
+				assert.EqualError(t, err, tc.error)
+				return
+			}
+
+			require.NoError(t, err)
 			assert.Equal(t, &tc.expected, actual)
 		})
 	}

--- a/internal/command/args_test.go
+++ b/internal/command/args_test.go
@@ -69,7 +69,7 @@ func TestParseArgsFromAnnotations(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, &tc.expected, actual)
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/internal/command/args_test.go
+++ b/internal/command/args_test.go
@@ -48,6 +48,7 @@ func TestParseArgsFromAnnotations(t *testing.T) {
 
 			if tc.error != "" {
 				assert.EqualError(t, err, tc.error)
+
 				return
 			}
 

--- a/internal/command/args_test.go
+++ b/internal/command/args_test.go
@@ -4,55 +4,59 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestParseArgs(t *testing.T) {
-	t.Run("Parse basic args", func(t *testing.T) {
-		annotations := map[string]string{
-			PreAnnotation:  `{}`,
-			ArgsAnnotation: `{"username":"foo","schema":"https"}`,
-		}
+func TestParseArgsFromAnnotations(t *testing.T) {
+	t.Parallel()
 
-		args, err := ParseArgsFromAnnotations(annotations, map[string]string{})
-		assert.NoError(t, err)
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		overrides   map[string]string
+		expected    Args
+	}{
+		{
+			name:        "basic",
+			annotations: map[string]string{ArgsAnnotation: `{"username":"foo","schema":"https"}`},
+			expected: Args{
+				"username": "foo",
+				"schema":   "https",
+			},
+		},
+		{
+			name:        "overrides",
+			annotations: map[string]string{ArgsAnnotation: `{"username":"foo","schema":"https"}`},
+			overrides:   map[string]string{"username": "bar"},
+			expected: Args{
+				"username": "bar",
+				"schema":   "https",
+			},
+		},
+		{
+			name: "overrides without default in annotation",
+			annotations: map[string]string{
+				ArgsAnnotation: "{}",
+			},
+			overrides: map[string]string{"username": "bar"},
+			expected:  Args{"username": "bar"},
+		},
+		{
+			name:     "no annotation",
+			expected: Args{},
+		},
+	}
 
-		expected := Args{
-			"username": "foo",
-			"schema":   "https",
-		}
+	for _, tc := range cases {
+		tc := tc
 
-		assert.Equal(t, &expected, args)
-	})
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("Parse with overrides", func(t *testing.T) {
-		annotations := map[string]string{
-			PreAnnotation:  `{}`,
-			ArgsAnnotation: `{"username":"foo","schema":"https"}`,
-		}
+			actual, err := ParseArgsFromAnnotations(tc.annotations, tc.overrides)
+			require.NoError(t, err)
 
-		args, err := ParseArgsFromAnnotations(annotations, map[string]string{
-			"username": "bar",
+			assert.Equal(t, &tc.expected, actual)
 		})
-		assert.NoError(t, err)
-
-		expected := Args{
-			"username": "bar",
-			"schema":   "https",
-		}
-
-		assert.Equal(t, &expected, args)
-	})
-
-	t.Run("Add overrides with no args annotation", func(t *testing.T) {
-		args, err := ParseArgsFromAnnotations(map[string]string{}, map[string]string{
-			"username": "bar",
-		})
-		assert.NoError(t, err)
-
-		expected := Args{
-			"username": "bar",
-		}
-
-		assert.Equal(t, &expected, args)
-	})
+	}
 }

--- a/internal/command/args_test.go
+++ b/internal/command/args_test.go
@@ -13,7 +13,7 @@ func TestParseArgs(t *testing.T) {
 			ArgsAnnotation: `{"username":"foo","schema":"https"}`,
 		}
 
-		args, err := parseArgs(annotations, map[string]string{})
+		args, err := ParseArgsFromAnnotations(annotations, map[string]string{})
 		assert.NoError(t, err)
 
 		expected := Args{
@@ -30,7 +30,7 @@ func TestParseArgs(t *testing.T) {
 			ArgsAnnotation: `{"username":"foo","schema":"https"}`,
 		}
 
-		args, err := parseArgs(annotations, map[string]string{
+		args, err := ParseArgsFromAnnotations(annotations, map[string]string{
 			"username": "bar",
 		})
 		assert.NoError(t, err)
@@ -44,7 +44,7 @@ func TestParseArgs(t *testing.T) {
 	})
 
 	t.Run("Add overrides with no args annotation", func(t *testing.T) {
-		args, err := parseArgs(map[string]string{}, map[string]string{
+		args, err := ParseArgsFromAnnotations(map[string]string{}, map[string]string{
 			"username": "bar",
 		})
 		assert.NoError(t, err)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -25,12 +25,12 @@ type Command struct {
 
 type templateInputs struct {
 	LocalPort int
-	Args      *Args
+	Args      Args
 	Outputs   map[string]string
 }
 
 // toCmd returns a golang cmd object from the calling command.
-func (c Command) toCmd(ctx context.Context, config *Config, cmdArgs *Args, outputs Outputs) (*exec.Cmd, error) {
+func (c Command) toCmd(ctx context.Context, config *Config, cmdArgs Args, outputs Outputs) (*exec.Cmd, error) {
 	name, args, err := c.render(config, cmdArgs, outputs, true)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func (c Command) toCmd(ctx context.Context, config *Config, cmdArgs *Args, outpu
 	return exec.CommandContext(ctx, name, args...), nil
 }
 
-func (c Command) render(config *Config, cmdArgs *Args, outputs Outputs, showSensitive bool) (name string, args []string, err error) {
+func (c Command) render(config *Config, cmdArgs Args, outputs Outputs, showSensitive bool) (name string, args []string, err error) {
 	name = c.Command[0]
 	rawArgs := []string{}
 
@@ -77,7 +77,7 @@ func (c Command) render(config *Config, cmdArgs *Args, outputs Outputs, showSens
 }
 
 // Display returns the command as a human readable string.
-func (c Command) Display(config *Config, cmdArgs *Args, outputs Outputs) (string, error) {
+func (c Command) Display(config *Config, cmdArgs Args, outputs Outputs) (string, error) {
 	str := []string{}
 
 	if c.Name != "" {
@@ -96,7 +96,7 @@ func (c Command) Display(config *Config, cmdArgs *Args, outputs Outputs) (string
 }
 
 // execute runs the command with the given config and outputs.
-func (c Command) execute(ctx context.Context, config *Config, args *Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (Outputs, error) {
+func (c Command) execute(ctx context.Context, config *Config, args Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (Outputs, error) {
 	outputs := Outputs{}
 
 	for k, v := range previousOutputs {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -14,7 +14,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{})
+		cmd, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo"}, cmd.Args)
@@ -26,7 +26,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "hello", "world"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{})
+		cmd, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "hello", "world"}, cmd.Args)
@@ -41,7 +41,7 @@ func TestToCmd(t *testing.T) {
 		cmd, err := c.toCmd(context.Background(), &Config{
 			LocalPort: 5678,
 			Verbose:   true,
-		}, &Args{}, Outputs{})
+		}, Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "5678"}, cmd.Args)
@@ -53,7 +53,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.Args.foo}}"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{"foo": "bar"}, Outputs{})
+		cmd, err := c.toCmd(context.Background(), &Config{}, Args{"foo": "bar"}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "bar"}, cmd.Args)
@@ -65,7 +65,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.Outputs.foo}}"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{
+		cmd, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{
 			"foo": {
 				Stdout: "hello world",
 				Stderr: "",
@@ -82,7 +82,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.DoesNotExist}}"},
 		}
 
-		_, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{})
+		_, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{})
 		assert.Error(t, err)
 	})
 
@@ -91,7 +91,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "foo"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, &Args{}, Outputs{})
+		cmd, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "foo"}, cmd.Args)

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -11,7 +11,7 @@ import (
 type Commands []*Command
 
 // execute runs each command in the calling slice sequentially using the passed config and the outputs accumulated to that point.
-func (c Commands) execute(ctx context.Context, config *Config, args *Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (outputs Outputs, err error) {
+func (c Commands) execute(ctx context.Context, config *Config, args Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (outputs Outputs, err error) {
 	outputs = Outputs{}
 	for k, v := range previousOutputs {
 		outputs[k] = v

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -32,7 +32,7 @@ func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cli
 
 	hooksConfig.LocalPort = localPort
 
-	args, err := parseArgs(fwdConfig.Pod.Annotations, cliArgs)
+	args, err := ParseArgsFromAnnotations(fwdConfig.Pod.Annotations, cliArgs)
 	if err != nil {
 		return err
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -32,10 +32,12 @@ func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cli
 
 	hooksConfig.LocalPort = localPort
 
-	args, err := ParseArgsFromAnnotations(fwdConfig.Pod.Annotations, cliArgs)
+	args, err := ParseArgsFromAnnotations(fwdConfig.Pod.Annotations)
 	if err != nil {
 		return err
 	}
+
+	args.Merge(cliArgs)
 
 	hooks, err := newHooks(fwdConfig.Pod.Annotations, hooksConfig)
 	if err != nil {


### PR DESCRIPTION
Refactors the `Args` type:

* Creates an exported `ParseArgsFromAnnotations`. Clarifies purpose (parse args from an outer structure not just args) and prepares for `run.go` to be extracted from the package
* Removes overrides from the parsing method into a `Merge` method on `Args`
* Returns `map` not `*map` (https://dave.cheney.net/2017/04/30/if-a-map-isnt-a-reference-variable-what-is-it)
* Converts tests to table tests
* Adds coverage for invalid JSON
* Runs tests in parallel

I'll try to do more of these refactors as I add test coverage.