### PR TITLE
gh: require test/lint check to merge

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,3 +5,10 @@ repository:
   topics: kubernetes, kubectl
   allow_auto_merge: true
   private: false
+branches:
+  - name: master
+    protection:
+      required_status_checks:
+        contexts:
+          - test
+          - lint


### PR DESCRIPTION
Adds required checks for merging, making it easier to enable auto-merge for a PR