### PR TITLE
Refactor `Command` parsing

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -29,8 +29,8 @@ type templateInputs struct {
 	Outputs   map[string]string
 }
 
-// toCmd returns a golang cmd object from the calling command.
-func (c Command) toCmd(ctx context.Context, config *Config, cmdArgs Args, outputs Outputs) (*exec.Cmd, error) {
+// ToCmd returns a Cmd object that can be used with the exec package.
+func (c Command) ToCmd(ctx context.Context, config *Config, cmdArgs Args, outputs Outputs) (*exec.Cmd, error) {
 	name, args, err := c.render(config, cmdArgs, outputs, true)
 	if err != nil {
 		return nil, err
@@ -103,7 +103,7 @@ func (c Command) execute(ctx context.Context, config *Config, args Args, previou
 		outputs[k] = v
 	}
 
-	cmd, err := c.toCmd(ctx, config, args, outputs)
+	cmd, err := c.ToCmd(ctx, config, args, outputs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -23,13 +23,16 @@ type Command struct {
 	DisplayName string   `json:"name"`
 }
 
+// TemplateData is the data passed to command templates to render the command arguments.
 type TemplateData struct {
 	LocalPort int
 	Args      Args
 	Outputs   map[string]string
 }
 
+// TemplateOptions are the configurable options used in different rendering contexts.
 type TemplateOptions struct {
+	// ShowSensitive indicates whether sensitive values should be shown. When false, sensitive values are replaced with asterisks.
 	ShowSensitive bool
 }
 
@@ -73,7 +76,6 @@ func (c Command) ToCmd(ctx context.Context, data TemplateData) (*exec.Cmd, error
 	args, err := c.Args(data, TemplateOptions{
 		ShowSensitive: true,
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -47,7 +47,8 @@ func (c Command) Args(data TemplateData, options TemplateOptions) ([]string, err
 		return []string{}, nil
 	}
 
-	args := c.Command[1:]
+	args := make([]string, len(c.Command)-1)
+	copy(args, c.Command[1:])
 
 	for i, raw := range args {
 		tpl, err := template.New(c.ID).Option("missingkey=error").Funcs(template.FuncMap{

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -95,7 +95,7 @@ func (c Command) Display(data TemplateData) (string, error) {
 	command := append([]string{name}, args...)
 	str = append(str, chalk.Green.Color(strings.Join(command, " ")))
 
-	return fmt.Sprintf("%s\n", strings.Join(str, ": ")), nil
+	return strings.Join(str, ": "), nil
 }
 
 // execute runs the command with the given config and outputs.
@@ -122,7 +122,7 @@ func (c Command) execute(ctx context.Context, config *Config, args Args, previou
 		return nil, err
 	}
 
-	fmt.Fprintf(streams.ErrOut, "> %s", cmdStr)
+	fmt.Fprintf(streams.ErrOut, "> %s\n", cmdStr)
 
 	if c.Interactive {
 		cmd.Stdout = streams.Out

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -168,9 +168,9 @@ func (c Command) execute(ctx context.Context, config *Config, args Args, previou
 	return outputs, err
 }
 
-// parseCommand returns a Command from an annotation storing a single command in json format.
-func parseComand(annotations map[string]string, key string) (command Command, err error) {
-	v, ok := annotations[key]
+// ParseCommandFromAnnotations returns a Command from annotations storing a single command in json format.
+func ParseCommandFromAnnotations(annotations map[string]string) (command Command, err error) {
+	v, ok := annotations[CommandAnnotation]
 	if !ok {
 		return command, nil
 	}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -216,6 +216,16 @@ func TestCommandArgs(t *testing.T) {
 	}
 }
 
+func TestCommandArgs_NoMutate(t *testing.T) {
+	cmd := Command{Command: []string{"echo", "{{.Args.foo}}"}}
+
+	args, err := cmd.Args(TemplateData{Args: Args{"foo": "bar"}}, TemplateOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"bar"}, args)
+	assert.Equal(t, []string{"echo", "{{.Args.foo}}"}, cmd.Command)
+}
+
 func TestParseCommandFromAnnotations(t *testing.T) {
 	t.Parallel()
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -53,7 +53,7 @@ func TestCommandToCmd(t *testing.T) {
 			error:   true,
 		},
 		{
-			name:    "un-exectuable template",
+			name:    "un-executable template",
 			command: Command{Command: []string{"echo", "{{.Invalid}}"}},
 			error:   true,
 		},

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToCmd(t *testing.T) {
+func TestCommandToCmd(t *testing.T) {
 	t.Run("returns a cmd with no arguments", func(t *testing.T) {
 		c := &Command{
 			ID:      "foo",
 			Command: []string{"echo"},
 		}
 
-		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{})
+		cmd, err := c.ToCmd(context.Background(), TemplateData{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo"}, cmd.Args)
@@ -26,7 +26,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "hello", "world"},
 		}
 
-		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{})
+		cmd, err := c.ToCmd(context.Background(), TemplateData{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "hello", "world"}, cmd.Args)
@@ -38,10 +38,9 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.LocalPort}}"},
 		}
 
-		cmd, err := c.ToCmd(context.Background(), &Config{
+		cmd, err := c.ToCmd(context.Background(), TemplateData{
 			LocalPort: 5678,
-			Verbose:   true,
-		}, Args{}, Outputs{})
+		})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "5678"}, cmd.Args)
@@ -53,7 +52,9 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.Args.foo}}"},
 		}
 
-		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{"foo": "bar"}, Outputs{})
+		cmd, err := c.ToCmd(context.Background(), TemplateData{
+			Args: Args{"foo": "bar"},
+		})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "bar"}, cmd.Args)
@@ -65,10 +66,9 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.Outputs.foo}}"},
 		}
 
-		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{
-			"foo": {
-				Stdout: "hello world",
-				Stderr: "",
+		cmd, err := c.ToCmd(context.Background(), TemplateData{
+			Outputs: map[string]string{
+				"foo": "hello world",
 			},
 		})
 		assert.NoError(t, err)
@@ -82,7 +82,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.DoesNotExist}}"},
 		}
 
-		_, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{})
+		_, err := c.ToCmd(context.Background(), TemplateData{})
 		assert.Error(t, err)
 	})
 
@@ -91,7 +91,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "foo"},
 		}
 
-		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{})
+		cmd, err := c.ToCmd(context.Background(), TemplateData{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "foo"}, cmd.Args)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ttacon/chalk"
 )
 
 func TestCommandToCmd(t *testing.T) {
@@ -22,30 +23,35 @@ func TestCommandToCmd(t *testing.T) {
 			expected: []string{"echo"},
 		},
 		{
-			name:     "with arguments",
+			name:     "arguments",
 			command:  Command{Command: []string{"echo", "hello", "world"}},
 			expected: []string{"echo", "hello", "world"},
 		},
 		{
-			name:     "with template",
+			name:     "template",
 			command:  Command{Command: []string{"echo", "{{.LocalPort}}"}},
 			data:     TemplateData{LocalPort: 5678},
 			expected: []string{"echo", "5678"},
 		},
 		{
-			name:     "with Arg template",
+			name:     "Arg template",
 			command:  Command{Command: []string{"echo", "{{.Args.foo}}"}},
 			data:     TemplateData{Args: Args{"foo": "bar"}},
 			expected: []string{"echo", "bar"},
 		},
 		{
-			name:     "with Outputs template",
+			name:     "Outputs template",
 			command:  Command{Command: []string{"echo", "{{.Outputs.foo}}"}},
 			data:     TemplateData{Outputs: map[string]string{"foo": "hello world"}},
 			expected: []string{"echo", "hello world"},
 		},
 		{
-			name:    "with invalid template",
+			name:    "un-parseable template",
+			command: Command{Command: []string{"echo", "{{.Invalid"}},
+			error:   true,
+		},
+		{
+			name:    "un-exectuable template",
 			command: Command{Command: []string{"echo", "{{.Invalid}}"}},
 			error:   true,
 		},
@@ -66,6 +72,57 @@ func TestCommandToCmd(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, cmd.Args)
+		})
+	}
+}
+
+func TestCommandDisplay(t *testing.T) {
+	cases := []struct {
+		name     string
+		command  Command
+		expected string
+		error    bool
+	}{
+		{
+			name:     "basic",
+			command:  Command{Command: []string{"echo", "hello", "world"}},
+			expected: chalk.Green.Color("echo hello world"),
+		},
+		{
+			name: "named",
+			command: Command{
+				Name:    "foo",
+				Command: []string{"echo", "hello", "world"},
+			},
+			expected: chalk.Cyan.Color("foo") + ": " + chalk.Green.Color("echo hello world"),
+		},
+		{
+			name:     "hide sensitive",
+			command:  Command{Command: []string{"echo", `{{ "secret" | sensitive }}`}},
+			expected: chalk.Green.Color("echo ********"),
+		},
+		{
+			name:    "error",
+			command: Command{Command: []string{"echo", "{{.Invalid}}"}},
+			error:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := tc.command.Display(TemplateData{})
+
+			if tc.error {
+				assert.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestCommandToCmd(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		command  Command
@@ -77,6 +79,8 @@ func TestCommandToCmd(t *testing.T) {
 }
 
 func TestCommandDisplay(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		command  Command
@@ -117,6 +121,47 @@ func TestCommandDisplay(t *testing.T) {
 
 			if tc.error {
 				assert.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestParseCommandFromAnnotations(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		expected    Command
+		error       string
+	}{
+		{
+			name:        "basic",
+			annotations: map[string]string{CommandAnnotation: `{"command": ["echo", "hello"]}`},
+			expected:    Command{Command: []string{"echo", "hello"}},
+		},
+		{
+			name:        "invalid json",
+			annotations: map[string]string{CommandAnnotation: ""},
+			error:       "unexpected end of JSON input",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := ParseCommandFromAnnotations(tc.annotations)
+
+			if tc.error != "" {
+				assert.EqualError(t, err, tc.error)
 
 				return
 			}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -14,7 +14,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{})
+		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo"}, cmd.Args)
@@ -26,7 +26,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "hello", "world"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{})
+		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "hello", "world"}, cmd.Args)
@@ -38,7 +38,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.LocalPort}}"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{
+		cmd, err := c.ToCmd(context.Background(), &Config{
 			LocalPort: 5678,
 			Verbose:   true,
 		}, Args{}, Outputs{})
@@ -53,7 +53,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.Args.foo}}"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, Args{"foo": "bar"}, Outputs{})
+		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{"foo": "bar"}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "bar"}, cmd.Args)
@@ -65,7 +65,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.Outputs.foo}}"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{
+		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{
 			"foo": {
 				Stdout: "hello world",
 				Stderr: "",
@@ -82,7 +82,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "{{.DoesNotExist}}"},
 		}
 
-		_, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{})
+		_, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{})
 		assert.Error(t, err)
 	})
 
@@ -91,7 +91,7 @@ func TestToCmd(t *testing.T) {
 			Command: []string{"echo", "foo"},
 		}
 
-		cmd, err := c.toCmd(context.Background(), &Config{}, Args{}, Outputs{})
+		cmd, err := c.ToCmd(context.Background(), &Config{}, Args{}, Outputs{})
 		assert.NoError(t, err)
 
 		assert.Equal(t, []string{"echo", "foo"}, cmd.Args)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -95,8 +95,8 @@ func TestCommandDisplay(t *testing.T) {
 		{
 			name: "named",
 			command: Command{
-				Name:    "foo",
-				Command: []string{"echo", "hello", "world"},
+				DisplayName: "foo",
+				Command:     []string{"echo", "hello", "world"},
 			},
 			expected: chalk.Cyan.Color("foo") + ": " + chalk.Green.Color("echo hello world"),
 		},

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -41,7 +41,7 @@ func TestParseCommands(t *testing.T) {
 		assert.NoError(t, err)
 
 		expected := Commands{
-			{ID: "", Command: []string{"echo", "post1"}, Name: "send post1 to stdout"},
+			{ID: "", Command: []string{"echo", "post1"}, DisplayName: "send post1 to stdout"},
 			{ID: "foo", Command: []string{"echo", "post2"}},
 		}
 		assert.Equal(t, expected, commands)

--- a/internal/command/hooks.go
+++ b/internal/command/hooks.go
@@ -24,7 +24,7 @@ func newHooks(annotations map[string]string, config *Config) (*Hooks, error) {
 		Post: post,
 	}
 
-	c, err := parseComand(annotations, CommandAnnotation)
+	c, err := ParseCommandFromAnnotations(annotations)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refactors all the logic around parsing and templating commands:

* Passes around `TemplateData` to methods that need to render commands, as opposed to various members
* Replaces `Render` with `Name()` and `Args(data, options)`
* Adds test coverage for `Display`
* Renames `ParseCommandFromAnnotations` and removes annotation key arg
* Adds test coverage for `ParseCommandFromAnnotations`
* Table tests
* Adds test coverage for un-parseable templates (un-executable were covered)

This achieves 100% coverage for everything except `execute()`, which has zero test coverage within the package itself. Shouldn't be too tricky to test but ran out of time today.