### PR TITLE
Refactor `Command` execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/howeyc/fsnotify v0.9.0
+	github.com/pborman/ansi v1.0.0 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pborman/ansi v1.0.0 h1:OqjHMhvlSuCCV5JT07yqPuJPQzQl+WXsiZ14gZsqOrQ=
+github.com/pborman/ansi v1.0.0/go.mod h1:SgWzwMAx1X/Ez7i90VqF8LRiQtx52pWDiQP+x3iGnzw=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -104,8 +104,8 @@ func (c Command) Display(data TemplateData) (string, error) {
 	return strings.Join(str, ": "), nil
 }
 
-// execute runs the command with the given config and outputs.
-func (c Command) execute(ctx context.Context, config *Config, args Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (Outputs, error) {
+// Execute runs the command with the given config and outputs.
+func (c Command) Execute(ctx context.Context, config *Config, args Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (Outputs, error) {
 	outputs := Outputs{}
 
 	for k, v := range previousOutputs {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -136,7 +136,7 @@ func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs
 
 	if config.Verbose {
 		ows = append(ows, streams.Out)
-		ews = append(ews, streams.ErrOut)
+		cmd.Stderr = streams.ErrOut
 	}
 
 	cmd.Stdout = io.MultiWriter(ows...)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -117,11 +117,7 @@ func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs
 		return nil, err
 	}
 
-	cmdStr, err := c.Display(data)
-	if err != nil {
-		return nil, err
-	}
-
+	cmdStr, _ := c.Display(data)
 	fmt.Fprintf(streams.ErrOut, "> %s\n", cmdStr)
 
 	if c.Interactive {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -136,7 +136,7 @@ func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs
 
 	if config.Verbose {
 		ows = append(ows, streams.Out)
-		cmd.Stderr = streams.ErrOut
+		ews = append(ews, streams.ErrOut)
 	}
 
 	cmd.Stdout = io.MultiWriter(ows...)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -309,6 +309,14 @@ func TestCommandExecute(t *testing.T) {
 			stderr:  "> cat\n",
 			stdout:  "hello\n",
 		},
+		{
+			name:     "verbose",
+			config:   Config{Verbose: true},
+			command:  Command{ID: "foo", Command: []string{"echo", "hello"}},
+			stderr:   "> echo hello\n",
+			stdout:   "hello\n",
+			expected: Outputs{"foo": "hello\n"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -283,6 +283,7 @@ func TestCommandExecute(t *testing.T) {
 		expected Outputs
 		stdout   string
 		stderr   string
+		error    bool
 	}{
 		{
 			name:    "no id",
@@ -295,6 +296,11 @@ func TestCommandExecute(t *testing.T) {
 			stderr:   "> echo hello\n",
 			expected: Outputs{"foo": "hello\n"},
 		},
+		{
+			name:    "invalid",
+			command: Command{Command: []string{"echo", "{{.Invalid}}"}},
+			error:   true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -304,6 +310,12 @@ func TestCommandExecute(t *testing.T) {
 
 			streams, _, stdout, stderr := genericclioptions.NewTestIOStreams()
 			outputs, err := tc.command.Execute(context.Background(), &tc.config, tc.args, tc.outputs, &streams)
+
+			if tc.error {
+				assert.Error(t, err)
+
+				return
+			}
 
 			require.NoError(t, err)
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -279,6 +279,7 @@ func TestCommandExecute(t *testing.T) {
 		args    Args
 		outputs Outputs
 		command Command
+		stdin   string
 
 		expected Outputs
 		stdout   string
@@ -301,6 +302,13 @@ func TestCommandExecute(t *testing.T) {
 			command: Command{Command: []string{"echo", "{{.Invalid}}"}},
 			error:   true,
 		},
+		{
+			name:    "interactive",
+			command: Command{Command: []string{"cat"}, Interactive: true},
+			stdin:   "hello\n",
+			stderr:  "> cat\n",
+			stdout:  "hello\n",
+		},
 	}
 
 	for _, tc := range cases {
@@ -308,7 +316,12 @@ func TestCommandExecute(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			streams, _, stdout, stderr := genericclioptions.NewTestIOStreams()
+			streams, stdin, stdout, stderr := genericclioptions.NewTestIOStreams()
+
+			if tc.stdin != "" {
+				stdin.Write([]byte(tc.stdin))
+			}
+
 			outputs, err := tc.command.Execute(context.Background(), &tc.config, tc.args, tc.outputs, &streams)
 
 			if tc.error {

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -18,7 +18,7 @@ func (c Commands) execute(ctx context.Context, config *Config, args Args, previo
 	}
 
 	for _, command := range c {
-		outputs, err = command.execute(ctx, config, args, outputs, streams)
+		outputs, err = command.Execute(ctx, config, args, outputs, streams)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -1,7 +1,0 @@
-package command
-
-// Output stores command output.
-type Output struct {
-	Stdout string
-	Stderr string
-}

--- a/internal/command/outputs.go
+++ b/internal/command/outputs.go
@@ -12,5 +12,6 @@ func (o Outputs) Append(id string, output string) Outputs {
 	}
 
 	outputs[id] = output
+
 	return outputs
 }

--- a/internal/command/outputs.go
+++ b/internal/command/outputs.go
@@ -1,15 +1,14 @@
 package command
 
-// Outputs is a collection of Output structs.
-type Outputs map[string]Output
+// Outputs is a collection of command outputs keyed by ID.
+type Outputs map[string]string
 
-// Stdout returns the output Stdout by the Output ID.
-func (o Outputs) Stdout() map[string]string {
-	out := map[string]string{}
-
-	for id, output := range o {
-		out[id] = output.Stdout
+// append copies the existing output, appending the new output, and returns the new, extended outputs.
+func (o Outputs) Append(id string, output string) Outputs {
+	outputs := Outputs{}
+	for k, v := range o {
+		outputs[k] = v
 	}
-
-	return out
+	outputs[id] = output
+	return outputs
 }

--- a/internal/command/outputs.go
+++ b/internal/command/outputs.go
@@ -3,12 +3,14 @@ package command
 // Outputs is a collection of command outputs keyed by ID.
 type Outputs map[string]string
 
-// append copies the existing output, appending the new output, and returns the new, extended outputs.
+// Append copies the existing output, appending the new output, and returns the new, extended outputs.
 func (o Outputs) Append(id string, output string) Outputs {
 	outputs := Outputs{}
+
 	for k, v := range o {
 		outputs[k] = v
 	}
+
 	outputs[id] = output
 	return outputs
 }

--- a/internal/command/outputs_test.go
+++ b/internal/command/outputs_test.go
@@ -1,0 +1,15 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOutputsAppend(t *testing.T) {
+	original := Outputs{"foo": "bar"}
+	extended := original.Append("baz", "qux")
+
+	assert.Equal(t, Outputs{"foo": "bar"}, original)
+	assert.Equal(t, Outputs{"foo": "bar", "baz": "qux"}, extended)
+}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -67,7 +67,7 @@ func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cli
 			hookErrChan <- err
 		}
 
-		if _, err = hooks.Command.execute(cancelCtx, hooksConfig, args, outputs, streams); err != nil {
+		if _, err = hooks.Command.Execute(cancelCtx, hooksConfig, args, outputs, streams); err != nil {
 			hookErrChan <- err
 		}
 


### PR DESCRIPTION
Refactors the `Execute()` method of `Command` and surrounding code:

* Removes `Stderr` from `Outputs` entirely, moving towards considering outputs as logical outputs rather than terminal outputs. 
* Adds `Append()` to `Outputs` to handle copy and add without mutation
* Adds test coverage for `Execute` in various configurations
* Strips ANSI in tests for simpler assertions, but tests could assert styles later

There are some potential behavioral changes I spotted, such as sending stdout from the command to stderr of the main program when verbose is enabled. But we can propose/discuss those changes with test coverage in place.