### PR TITLE
Fix user agent not set properly for factory requests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,5 +17,6 @@ linters:
     - maligned
     - stylecheck
     - varnamelen
+    - ireturn
 issues:
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,5 @@ linters:
     - maligned
     - stylecheck
     - varnamelen
-    - ireturn
 issues:
   exclude-use-default: false

--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -35,8 +35,8 @@ func newForwardCommand(streams *genericclioptions.IOStreams, version string) *co
 				return err
 			}
 
-			client := forwarder.NewClient(cmdutil.NewMatchVersionFlags(kubeConfigFlags), podTimeout, streams)
-			if err := client.Init(overrides, version); err != nil {
+			client := forwarder.NewClient(podTimeout, streams)
+			if err := client.Init(cmdutil.NewMatchVersionFlags(kubeConfigFlags), overrides, version); err != nil {
 				return err
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/howeyc/fsnotify v0.9.0
-	github.com/pborman/ansi v1.0.0 // indirect
+	github.com/pborman/ansi v1.0.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0

--- a/internal/forwarder/client.go
+++ b/internal/forwarder/client.go
@@ -24,10 +24,10 @@ type Client struct {
 // NewClient returns an uninitialized forwarding client.
 func NewClient(timeout time.Duration, streams *genericclioptions.IOStreams) *Client {
 	return &Client{
-		factory:    nil,
 		timeout:    timeout,
 		streams:    streams,
 		clientset:  nil,
+		factory:    nil,
 		restConfig: nil,
 		userConfig: nil,
 	}
@@ -38,8 +38,8 @@ func (c *Client) Init(getter *cmdutil.MatchVersionFlags, overrides clientcmd.Con
 	userAgent := fmt.Sprintf("kubectl-exec-forward/%s", version)
 
 	c.factory = cmdutil.NewFactory(restGetter{
-		getter:    getter,
-		userAgent: userAgent,
+		restClientGetter: getter,
+		userAgent:        userAgent,
 	})
 
 	kc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(

--- a/internal/forwarder/rest.go
+++ b/internal/forwarder/rest.go
@@ -1,22 +1,21 @@
 package forwarder
 
 import (
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
+
+type restClientGetter genericclioptions.RESTClientGetter
 
 // restGetter wraps the passed getter, allowing for extended behavior on the interface methods.
 type restGetter struct {
-	getter    genericclioptions.RESTClientGetter
+	restClientGetter
 	userAgent string
 }
 
 // ToRESTConfig returns restconfig.
 func (r restGetter) ToRESTConfig() (*rest.Config, error) {
-	rc, err := r.getter.ToRESTConfig()
+	rc, err := r.restClientGetter.ToRESTConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -24,19 +23,4 @@ func (r restGetter) ToRESTConfig() (*rest.Config, error) {
 	rc.UserAgent = r.userAgent
 
 	return rc, nil
-}
-
-// ToDiscoveryClient returns discovery client.
-func (r restGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
-	return r.getter.ToDiscoveryClient()
-}
-
-// ToRESTMapper returns a restmapper.
-func (r restGetter) ToRESTMapper() (meta.RESTMapper, error) {
-	return r.getter.ToRESTMapper()
-}
-
-// ToRawKubeConfigLoader return kubeconfig loader as-is.
-func (r restGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
-	return r.getter.ToRawKubeConfigLoader()
 }

--- a/internal/forwarder/rest.go
+++ b/internal/forwarder/rest.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// restGetter wraps the passed getter, allowing for extended behavior on the interface methods
+// restGetter wraps the passed getter, allowing for extended behavior on the interface methods.
 type restGetter struct {
 	getter    genericclioptions.RESTClientGetter
 	userAgent string

--- a/internal/forwarder/rest.go
+++ b/internal/forwarder/rest.go
@@ -1,0 +1,41 @@
+package forwarder
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type restGetter struct {
+	getter    genericclioptions.RESTClientGetter
+	userAgent string
+}
+
+// ToRESTConfig returns restconfig.
+func (r restGetter) ToRESTConfig() (*rest.Config, error) {
+	rc, err := r.getter.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	rc.UserAgent = r.userAgent
+
+	return rc, nil
+}
+
+// ToDiscoveryClient returns discovery client.
+func (r restGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return r.getter.ToDiscoveryClient()
+}
+
+// ToRESTMapper returns a restmapper.
+func (r restGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	return r.getter.ToRESTMapper()
+}
+
+// ToRawKubeConfigLoader return kubeconfig loader as-is.
+func (r restGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return r.getter.ToRawKubeConfigLoader()
+}

--- a/internal/forwarder/rest.go
+++ b/internal/forwarder/rest.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// restGetter wraps the passed getter, allowing for extended behavior on the interface methods
 type restGetter struct {
 	getter    genericclioptions.RESTClientGetter
 	userAgent string


### PR DESCRIPTION
I noticed that the user agent is set to a default for the factory runtime.Object request. 

```
# good
kubectl-exec-forward/dev
# bad
kubectl-exec-forward/v0.0.0 (darwin/amd64) kubernetes/$Format
```

Changes:
- Moves the client.factory creation into Init, instead of on the New func for the client to take advantage of the passed version string used for the clientset. The factory is used to fetch the generic runtime.Object to handle generic TYPE resources in the CLI arguments.
- Adds an implementation of the `genericclioptions.RESTClientGetter` interface, ensuring that UserAgent is set on the returned rest config.

The stack:
- standard kubectl flags parsed into a generic REST getter([kubect-exec-forward/cmd/forward.go](https://github.com/TakeScoop/kubectl-exec-forward/blob/master/cmd/forward.go#L22))
- the getter is used to create a more specified REST getter ([kubect-exec-forward/cmd/forward.go](https://github.com/TakeScoop/kubectl-exec-forward/blob/master/cmd/forward.go#L38))
- the getter is wrapped for some added functionality ([kubectl/cmd/util/kubectl_match_version.go](https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/util/kubectl_match_version.go#L106-L110))
- This enhanced getter is where the rest configuration is generated, although it just calls through to the orginal getter ([kubectl/cmd/util/kubectl_match_version.go](https://github.com/kubernetes/kubectl/blob/ce9f95af72bc760e7eaca946b593ec9f16de389f/pkg/cmd/util/kubectl_match_version.go#L70-L81))
- The enhanced getter calls a set defaults function on the returned rest config ([kubectl/cmd/util/kubectl_match_version.go](https://github.com/kubernetes/kubectl/blob/ce9f95af72bc760e7eaca946b593ec9f16de389f/pkg/cmd/util/kubectl_match_version.go#L79))
- rest defaults are applied, setting the user agent to a default ([client-go/rest/config.go](https://github.com/kubernetes/client-go/blob/255c7965135603be097ad4dc482924f869bd4a6a/rest/config.go#L454-L459))

There doesn't seem to be a way to set the user agent going _in_ to the creation of the REST getter, but we can wrap the getter similar to what they've done with `MatchVersionFlags`. 

To me it seems like the factory approach to generic objects might not be ideal. Maybe we could use the go client's [dynamicResourceClient](https://github.com/kubernetes/client-go/blob/255c7965135603be097ad4dc482924f869bd4a6a/dynamic/simple.go#L63-L95) in its place. It takes a REST config directly instead of a REST getter.

fixes #68 