### PR TITLE
Test `Commands`, move output merging logic up

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -105,7 +105,7 @@ func (c Command) Display(data TemplateData) (string, error) {
 }
 
 // Execute runs the command with the given config and outputs.
-func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs Outputs, streams *genericclioptions.IOStreams) (Outputs, error) {
+func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs Outputs, streams *genericclioptions.IOStreams) ([]byte, error) {
 	data := TemplateData{
 		LocalPort: config.LocalPort,
 		Args:      args,
@@ -125,7 +125,8 @@ func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs
 		cmd.Stderr = streams.ErrOut
 		cmd.Stdin = streams.In
 
-		return outputs, cmd.Run()
+		// interactive commands cannot return
+		return []byte{}, cmd.Run()
 	}
 
 	outBuff := new(bytes.Buffer)
@@ -154,11 +155,7 @@ func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs
 		return nil, err
 	}
 
-	if c.ID != "" {
-		outputs = outputs.Append(c.ID, outBuff.String())
-	}
-
-	return outputs, nil
+	return outBuff.Bytes(), nil
 }
 
 // ParseCommandFromAnnotations returns a Command from annotations storing a single command in json format.

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -282,21 +282,22 @@ func TestCommandExecute(t *testing.T) {
 		command Command
 		stdin   string
 
-		expected Outputs
-		stdout   string
-		stderr   string
-		error    bool
+		output string
+		stdout string
+		stderr string
+		error  bool
 	}{
 		{
 			name:    "no id",
 			command: Command{Command: []string{"echo", "hello"}},
 			stderr:  "> echo hello\n",
+			output:  "hello\n",
 		},
 		{
-			name:     "output",
-			command:  Command{ID: "foo", Command: []string{"echo", "hello"}},
-			stderr:   "> echo hello\n",
-			expected: Outputs{"foo": "hello\n"},
+			name:    "output",
+			command: Command{ID: "foo", Command: []string{"echo", "hello"}},
+			stderr:  "> echo hello\n",
+			output:  "hello\n",
 		},
 		{
 			name:    "invalid",
@@ -311,12 +312,12 @@ func TestCommandExecute(t *testing.T) {
 			stdout:  "hello\n",
 		},
 		{
-			name:     "verbose",
-			config:   Config{Verbose: true},
-			command:  Command{ID: "foo", Command: []string{"echo", "hello"}},
-			stderr:   "> echo hello\n",
-			stdout:   "hello\n",
-			expected: Outputs{"foo": "hello\n"},
+			name:    "verbose",
+			config:  Config{Verbose: true},
+			command: Command{Command: []string{"echo", "hello"}},
+			stderr:  "> echo hello\n",
+			stdout:  "hello\n",
+			output:  "hello\n",
 		},
 		{
 			name: "run with error",
@@ -359,7 +360,7 @@ func TestCommandExecute(t *testing.T) {
 				stdin.Write([]byte(tc.stdin))
 			}
 
-			outputs, err := tc.command.Execute(context.Background(), &tc.config, tc.args, tc.outputs, &streams)
+			output, err := tc.command.Execute(context.Background(), &tc.config, tc.args, tc.outputs, &streams)
 
 			if tc.error {
 				assert.Error(t, err)
@@ -372,7 +373,7 @@ func TestCommandExecute(t *testing.T) {
 
 			assert.Equal(t, tc.stderr, string(plainStderr))
 			assert.Equal(t, tc.stdout, stdout.String())
-			assert.Equal(t, tc.expected, outputs)
+			assert.Equal(t, tc.output, string(output))
 		})
 	}
 }

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -10,8 +10,8 @@ import (
 // Commands stores a slice of commands and provides some helper execution methods.
 type Commands []*Command
 
-// execute runs each command in the calling slice sequentially using the passed config and the outputs accumulated to that point.
-func (c Commands) execute(ctx context.Context, config *Config, args Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (outputs Outputs, err error) {
+// Execute runs each command in the calling slice sequentially using the passed config and the outputs accumulated to that point.
+func (c Commands) Execute(ctx context.Context, config *Config, args Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (outputs Outputs, err error) {
 	outputs = Outputs{}
 	for k, v := range previousOutputs {
 		outputs[k] = v

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -11,16 +11,15 @@ import (
 type Commands []*Command
 
 // Execute runs each command in the calling slice sequentially using the passed config and the outputs accumulated to that point.
-func (c Commands) Execute(ctx context.Context, config *Config, args Args, previousOutputs Outputs, streams *genericclioptions.IOStreams) (outputs Outputs, err error) {
-	outputs = Outputs{}
-	for k, v := range previousOutputs {
-		outputs[k] = v
-	}
-
+func (c Commands) Execute(ctx context.Context, config *Config, args Args, outputs Outputs, streams *genericclioptions.IOStreams) (Outputs, error) {
 	for _, command := range c {
-		outputs, err = command.Execute(ctx, config, args, outputs, streams)
+		output, err := command.Execute(ctx, config, args, outputs, streams)
 		if err != nil {
 			return nil, err
+		}
+
+		if command.ID != "" {
+			outputs = outputs.Append(command.ID, string(output))
 		}
 	}
 

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -1,10 +1,93 @@
 package command
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
+
+func TestCommandsExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		commands Commands
+		outputs  Outputs
+
+		expected Outputs
+		error    bool
+	}{
+		{
+			name: "with outputs",
+			commands: Commands{
+				&Command{
+					ID:      "foo",
+					Command: []string{"echo", "hello"},
+				},
+				&Command{
+					ID:      "bar",
+					Command: []string{"sh", "-c", "echo '{{ .Outputs.foo | trim }}' | rev"},
+				},
+			},
+			expected: Outputs{"foo": "hello\n", "bar": "olleh\n"},
+		},
+		{
+			name: "no outputs",
+			commands: Commands{
+				&Command{
+					Command: []string{"echo", "hello"},
+				},
+			},
+		},
+		{
+			name: "existing outputs",
+			outputs: Outputs{
+				"foo": "hello",
+			},
+			commands: Commands{
+				&Command{
+					ID:      "bar",
+					Command: []string{"echo", "{{ .Outputs.foo }}"},
+				},
+			},
+			expected: Outputs{"foo": "hello", "bar": "hello\n"},
+		},
+		{
+			name: "error",
+			commands: Commands{
+				&Command{
+					Command: []string{"false"},
+				},
+			},
+			error: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			streams := genericclioptions.NewTestIOStreamsDiscard()
+
+			outputs, err := tc.commands.Execute(context.Background(), &Config{}, Args{}, tc.outputs, &streams)
+
+			if tc.error {
+				assert.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, outputs)
+		})
+	}
+}
 
 func TestParseCommands(t *testing.T) {
 	t.Run("Parse basic command", func(t *testing.T) {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -46,7 +46,7 @@ func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cli
 
 	outputs := Outputs{}
 
-	if outputs, err = hooks.Pre.execute(ctx, hooksConfig, args, outputs, streams); err != nil {
+	if outputs, err = hooks.Pre.Execute(ctx, hooksConfig, args, outputs, streams); err != nil {
 		return err
 	}
 
@@ -63,7 +63,7 @@ func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cli
 
 		hooksConfig.LocalPort = conn.Local
 
-		if outputs, err = hooks.Post.execute(cancelCtx, hooksConfig, args, outputs, streams); err != nil {
+		if outputs, err = hooks.Post.Execute(cancelCtx, hooksConfig, args, outputs, streams); err != nil {
 			hookErrChan <- err
 		}
 


### PR DESCRIPTION
* Moves `Command` output logic to `Commands`. All `Command` will return output, the `Commands` sequence contains the logic that a command with `ID` has output another `Command` could care about.
* Adds tests for `Execute()` for `Commands` covering migrated output logic

This brings coverage for the `command` package up to nearly 100% outside of `run.go`. In maybe 1-2 more PRs for this round of refactoring, I'll separate out annotation parsing into its own package that depends on `commands` and then `run.go` to its own `execforward` (i.e. main) package with tests.

Separately, `package forwarder` could use some coverage as well.