### PR TITLE
pass `genericclioptions.IOStreams` as value

### DIFF
--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -16,7 +16,7 @@ import (
 )
 
 // newForwardCommand returns the command for forwarding to Kubernetes resources.
-func newForwardCommand(streams *genericclioptions.IOStreams, version string) *cobra.Command {
+func newForwardCommand(streams genericclioptions.IOStreams, version string) *cobra.Command {
 	overrides := clientcmd.ConfigOverrides{}
 
 	kubeConfigFlags := genericclioptions.NewConfigFlags(false)
@@ -92,7 +92,7 @@ func newForwardCommand(streams *genericclioptions.IOStreams, version string) *co
 
 // Execute executes the forward command.
 func Execute(version string) {
-	cmd := newForwardCommand(&genericclioptions.IOStreams{
+	cmd := newForwardCommand(genericclioptions.IOStreams{
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,
 		In:     os.Stdin,

--- a/cmd/forward_test.go
+++ b/cmd/forward_test.go
@@ -114,7 +114,7 @@ func TestRunForwardCommand(t *testing.T) {
 	out := &SafeBuffer{}
 	outErr := &SafeBuffer{}
 
-	cmd := newForwardCommand(&genericclioptions.IOStreams{
+	cmd := newForwardCommand(genericclioptions.IOStreams{
 		Out:    out,
 		ErrOut: outErr,
 	}, "0.0.0")

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -105,7 +105,7 @@ func (c Command) Display(data TemplateData) (string, error) {
 }
 
 // Execute runs the command with the given config and outputs.
-func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs Outputs, streams *genericclioptions.IOStreams) ([]byte, error) {
+func (c Command) Execute(ctx context.Context, config *Config, args Args, outputs Outputs, streams genericclioptions.IOStreams) ([]byte, error) {
 	data := TemplateData{
 		LocalPort: config.LocalPort,
 		Args:      args,

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -360,7 +360,7 @@ func TestCommandExecute(t *testing.T) {
 				stdin.Write([]byte(tc.stdin))
 			}
 
-			output, err := tc.command.Execute(context.Background(), &tc.config, tc.args, tc.outputs, &streams)
+			output, err := tc.command.Execute(context.Background(), &tc.config, tc.args, tc.outputs, streams)
 
 			if tc.error {
 				assert.Error(t, err)

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -11,7 +11,7 @@ import (
 type Commands []*Command
 
 // Execute runs each command in the calling slice sequentially using the passed config and the outputs accumulated to that point.
-func (c Commands) Execute(ctx context.Context, config *Config, args Args, outputs Outputs, streams *genericclioptions.IOStreams) (Outputs, error) {
+func (c Commands) Execute(ctx context.Context, config *Config, args Args, outputs Outputs, streams genericclioptions.IOStreams) (Outputs, error) {
 	for _, command := range c {
 		output, err := command.Execute(ctx, config, args, outputs, streams)
 		if err != nil {

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -72,9 +72,7 @@ func TestCommandsExecute(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			streams := genericclioptions.NewTestIOStreamsDiscard()
-
-			outputs, err := tc.commands.Execute(context.Background(), &Config{}, Args{}, tc.outputs, &streams)
+			outputs, err := tc.commands.Execute(context.Background(), &Config{}, Args{}, tc.outputs, genericclioptions.NewTestIOStreamsDiscard())
 
 			if tc.error {
 				assert.Error(t, err)

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Run executes hooks found on the passed resource's underlying pod annotations and opens a forwarding connection to the resource.
-func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cliArgs map[string]string, resource string, portMap string, streams *genericclioptions.IOStreams) error {
+func Run(ctx context.Context, client *forwarder.Client, hooksConfig *Config, cliArgs map[string]string, resource string, portMap string, streams genericclioptions.IOStreams) error {
 	fwdConfig, err := client.NewConfig(resource, portMap)
 	if err != nil {
 		return err

--- a/internal/forwarder/client.go
+++ b/internal/forwarder/client.go
@@ -18,11 +18,11 @@ type Client struct {
 	userConfig clientcmd.ClientConfig
 	factory    cmdutil.Factory
 	timeout    time.Duration
-	streams    *genericclioptions.IOStreams
+	streams    genericclioptions.IOStreams
 }
 
 // NewClient returns an uninitialized forwarding client.
-func NewClient(timeout time.Duration, streams *genericclioptions.IOStreams) *Client {
+func NewClient(timeout time.Duration, streams genericclioptions.IOStreams) *Client {
 	return &Client{
 		timeout:    timeout,
 		streams:    streams,


### PR DESCRIPTION
Passes around `IOStreams` values rather than pointers. `IOStreams` is a struct of interfaces:

https://pkg.go.dev/k8s.io/cli-runtime/pkg/genericclioptions#IOStreams

Structs of pointers can generally be passed by value, which slightly simplifies the code. And for this reason, test helper methods in `genericclioptions` return a streams value and not `*IOStreams`.

<hr>

When we pass around structs by value, their contents are copied. If those contents are values, this means that the received struct cannot mutate the passed value, only return a new modified copy:

https://go.dev/play/p/Y_HaqaOcm8u

However, if we introduce struct pointers inside those values the overall behavior changes:

https://go.dev/play/p/0XO3w2qg4qq

Values are still passed by copy, but now the field in the struct is a pointer. Copying the pointer means that if, in my function call, I replace the pointer with a new one, it will not change `count.Value` in `main()`. Unless I do that, both copies of the struct still point to the same memory. And so `c.Value.V += 1` modifies the memory that both copies of the `Count` struct point to (that of `main()` and that of `increment()`). 

<hr>

`os.Stdout` and friends are `*File` objects. `NewTestIOStreams()` also uses pointers:

https://github.com/kubernetes/cli-runtime/blob/v0.23.1/pkg/genericclioptions/io_options.go#L37

It generally wouldn't make sense to have streams be non-pointers since their purpose is to be a shared output (or input) buffer. So `genericclioptions` intends you to use `IOStreams` as a value, and that's how you'll see it used in general:

https://github.com/search?q=genericclioptions+IOStreams&type=code

If you pass around struct pointers, a function receiving `IOStreams` can run `streams.Out = myWriter` and affect outer function scopes. That's generally not behavior you'd want, functions should be able to read (In) or write (Out, OutErr) streams but not modify the stream config.