### PR TITLE
Upload coverage data to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Test
-        run: go test -race -v ./...
+        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+      
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1


### PR DESCRIPTION
I've installed the Codecov app for our org. For now, the integration is only accessible for public repos. Uploading coverage for public repos does not require authentication.