### PR TITLE
disable exhaustruct and nonamedreturns linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,5 @@ jobs:
         with:
           go-version: 1.17
       - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.46

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,5 +17,7 @@ linters:
     - maligned
     - stylecheck
     - varnamelen
+    - exhaustruct
+    - nonamedreturns
 issues:
   exclude-use-default: false


### PR DESCRIPTION
`exhaustruct` replaces `exhaustivestruct`. `nonamedreturns` suggests return signatures have identifiers in addition to types. Both are disruptive and don't make sense as defaults.