### PR TITLE
go: enable version file, built-in caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,26 +15,11 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: go.mod
+          cache: true
 
       - name: Start minikube
         uses: medyagh/setup-minikube@master
-
-      - name: Set cache paths
-        id: go-cache-paths
-        run: |
-          echo "::set-output name=build::$(go env GOCACHE)"
-          echo "::set-output name=mod::$(go env GOMODCACHE)"
-
-      - name: Go cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ steps.go-cache-paths.outputs.build }}
-            ${{ steps.go-cache-paths.outputs.mod }}
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Test
         run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...


### PR DESCRIPTION
When testing this repository, instead of using a hardcoded Go version (1.17), this reads the version declared in `go.mod` using new-ish functionality in `actions/setup-go`. While the former has to be updated manually, Renovate can update `go.mod` (eg, #110). This should resolve the failing checks in #114, which are seemingly failing because of the older Go version being used to invoke the tests.

Additionally, this also enables `actions/setup-go`'s built-in caching rather than calling `actions/cache` separately as was previously required.