### PR TITLE
go: use version file for lint, update golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.46

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46
+          version: v1.49

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,0 +1,4 @@
+// Package cmd implements the exec-forward CLI. It is responsible for parsing
+// command line arguments and delegates all other functionality to internal
+// packages.
+package cmd

--- a/internal/annotation/doc.go
+++ b/internal/annotation/doc.go
@@ -1,0 +1,4 @@
+// Package annotation is responsible for decoding command specifications from
+// annotations on a Kubernetes pod and constructing a runner using the `command`
+// package.
+package annotation

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -80,7 +80,7 @@ func (c Command) ToCmd(ctx context.Context, data TemplateData) (*exec.Cmd, error
 		return nil, err
 	}
 
-	// nolint:gosec
+	//nolint:gosec
 	return exec.CommandContext(ctx, c.Name(), args...), nil
 }
 

--- a/internal/command/doc.go
+++ b/internal/command/doc.go
@@ -1,0 +1,4 @@
+// Package command implements a command runner that executes a series of local commands based on a
+// JSON specification. Commands can interpolate user-provided arguments, remote configuration, or
+// outputs from other commands.
+package command

--- a/internal/execforward/doc.go
+++ b/internal/execforward/doc.go
@@ -1,0 +1,4 @@
+// Package execforward is the main entrypoint that provides the high level
+// functionality used by the exec-forward CLI. It defines the lifecycle of a
+// forwarding connection, including "pre" and "post" connect hooks.
+package execforward

--- a/internal/forwarder/doc.go
+++ b/internal/forwarder/doc.go
@@ -1,0 +1,5 @@
+// Package forwarder implements a Kubernetes pod port-forwarding client, similar
+// to the `kubectl port-forward` command. Like kubectl, it can resolve an
+// appropriate pod from a higher level object's selectors, e.g., a Service or
+// Deployment.
+package forwarder

--- a/internal/forwarder/ports.go
+++ b/internal/forwarder/ports.go
@@ -41,18 +41,17 @@ func splitPort(port string) (local, remote string) {
 func translateServicePortToTargetPort(port string, svc corev1.Service, pod corev1.Pod) (string, error) {
 	localPort, remotePort := splitPort(port)
 
-	// nolint:gosec
-	portnum, err := strconv.Atoi(remotePort)
+	portnum, err := strconv.ParseInt(remotePort, 10, 32)
 	if err != nil {
 		svcPort, err := util.LookupServicePortNumberByName(svc, remotePort)
 		if err != nil {
 			return "", err
 		}
 
-		portnum = int(svcPort)
+		portnum = int64(svcPort)
 
 		if localPort == remotePort {
-			localPort = strconv.Itoa(portnum)
+			localPort = strconv.FormatInt(portnum, 10)
 		}
 	}
 

--- a/internal/forwarder/ports_test.go
+++ b/internal/forwarder/ports_test.go
@@ -1,0 +1,157 @@
+package forwarder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestTranslateServicePortToTargetPort(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+
+		port    string
+		service corev1.Service
+		pod     corev1.Pod
+
+		expected string
+		error    string
+	}{
+		{
+			name: "basic",
+			port: "3000",
+			service: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:       3000,
+							TargetPort: intstr.FromInt(4000),
+						},
+					},
+				},
+			},
+			expected: "3000:4000",
+		},
+		{
+			name: "same local and remote",
+			port: "3000",
+			service: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:       3000,
+							TargetPort: intstr.FromInt(3000),
+						},
+					},
+				},
+			},
+			expected: "3000",
+		},
+		{
+			name: "number to name",
+			port: "3000",
+			service: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:       3000,
+							TargetPort: intstr.FromString("http"),
+						},
+					},
+				},
+			},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "http",
+									ContainerPort: 4000,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "3000:4000",
+		},
+		{
+			name: "name to number",
+			port: "http",
+			service: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       3000,
+							TargetPort: intstr.FromInt(4000),
+						},
+					},
+				},
+			},
+			expected: "3000:4000",
+		},
+		{
+			name: "name not found",
+			port: "http",
+			service: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-svc",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "grpc",
+							Port:       3000,
+							TargetPort: intstr.FromInt(4000),
+						},
+					},
+				},
+			},
+			error: `Service 'my-svc' does not have a named port 'http'`,
+		},
+		{
+			name: "number not found",
+			port: "3000",
+			service: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-svc",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:       3001,
+							TargetPort: intstr.FromInt(4000),
+						},
+					},
+				},
+			},
+			error: "Service my-svc does not have a service port 3000",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := translateServicePortToTargetPort(tc.port, tc.service, tc.pod)
+
+			if tc.error != "" {
+				assert.EqualError(t, err, tc.error)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/internal/forwarder/ports_test.go
+++ b/internal/forwarder/ports_test.go
@@ -147,6 +147,7 @@ func TestTranslateServicePortToTargetPort(t *testing.T) {
 
 			if tc.error != "" {
 				assert.EqualError(t, err, tc.error)
+
 				return
 			}
 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Package main is the entrypoint for the exec-forward CLI.
 package main
 
 import (


### PR DESCRIPTION
Same as #115, but for the linting workflow. Also updates the linter, since Go 1.18 introduces some notable changes (including generics) with evolving support in golangci-lint.

Upgrading the linter raised some new warnings, which I've resolved here. In the case where this required a change to code and not just formatting, I've added test coverage against the modified function where previously there was none.