### PR TITLE
release: use go version from `go.mod`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: go.mod
       - name: Generate token
         id: token
         uses: tibdex/github-app-token@v1


### PR DESCRIPTION
A corresponding update to #115 which uses the same Go version used for testing to release. Currently, the release process is failing because the release build is attempted with an incompatible Go version.